### PR TITLE
Adds tuning for packet capture accuracy

### DIFF
--- a/scanner/fullscan.go
+++ b/scanner/fullscan.go
@@ -172,3 +172,8 @@ func (s *FullScanner) IncludeVendorInfo(value bool) {
 	s.arpScanner.IncludeVendorInfo(value)
 	s.options = append(s.options, WithVendorInfo(value))
 }
+
+func (s *FullScanner) SetAccuracy(accuracy Accuracy) {
+	s.arpScanner.SetAccuracy(accuracy)
+	s.options = append(s.options, WithAccuracy(accuracy))
+}

--- a/scanner/options.go
+++ b/scanner/options.go
@@ -6,6 +6,33 @@ import "time"
 
 type ScannerOption = func(s Scanner)
 
+type Accuracy int
+
+const (
+	LOW_ACCURACY    Accuracy = 0
+	MEDIUM_ACCURACY Accuracy = 1
+	HIGH_ACCURACY   Accuracy = 2
+)
+
+func (a Accuracy) Duration() time.Duration {
+	switch a {
+	case LOW_ACCURACY:
+		return time.Microsecond * 100
+	case MEDIUM_ACCURACY:
+		return time.Microsecond * 500
+	case HIGH_ACCURACY:
+		return time.Millisecond
+	default:
+		return time.Millisecond
+	}
+}
+
+func WithAccuracy(accuracy Accuracy) ScannerOption {
+	return func(s Scanner) {
+		s.SetAccuracy(accuracy)
+	}
+}
+
 func WithRequestNotifications(cb func(a *Request)) ScannerOption {
 	return func(s Scanner) {
 		s.SetRequestNotifications(cb)

--- a/scanner/types.go
+++ b/scanner/types.go
@@ -29,6 +29,7 @@ type Scanner interface {
 	SetRequestNotifications(cb func(a *Request))
 	SetIdleTimeout(d time.Duration)
 	IncludeVendorInfo(value bool)
+	SetAccuracy(accuracy Accuracy)
 }
 
 // Status represents possible server statues


### PR DESCRIPTION
- Uses lastPacketSentAt for idle timeout calculation rather than lastPacketReceivedAt
- Processes packets in separate goroutine
- Uses ticker limiter to tune accuracy rather than spinning up a new pcap handle on each request