### PR TITLE
Fix issue with polling scanner

### DIFF
--- a/pkg/scanner/arpscan.go
+++ b/pkg/scanner/arpscan.go
@@ -222,7 +222,9 @@ func (s *ArpScanner) readPackets() {
 	}()
 
 	defer func() {
-		stopChan <- struct{}{}
+		go func() {
+			stopChan <- struct{}{}
+		}()
 		s.reset()
 	}()
 

--- a/pkg/scanner/synscan.go
+++ b/pkg/scanner/synscan.go
@@ -260,7 +260,9 @@ func (s *SynScanner) readPackets() {
 	}()
 
 	defer func() {
-		stopChan <- struct{}{}
+		go func() {
+			stopChan <- struct{}{}
+		}()
 		s.reset()
 	}()
 


### PR DESCRIPTION
Ensure the signal to stop reading packets is called in a goroutine to prevent blocking. Otherwise we won't be able to reset the scanner to allow for polling